### PR TITLE
Prevent initial directory from throwing an exception that crashes the app

### DIFF
--- a/KoAR.Core/Amalur.cs
+++ b/KoAR.Core/Amalur.cs
@@ -55,20 +55,28 @@ namespace KoAR.Core
         internal static TValue GetOrDefault<TKey, TValue>(this IReadOnlyDictionary<TKey, TValue> dictionary, TKey key, TValue? defaultValue = default)
             where TValue : class => dictionary.TryGetValue(key, out TValue res) ? res : defaultValue;
 
-        public static string? FindSaveGameDirectory()
+        public static string FindSaveGameDirectory()
         {
-            // GOG
-            var directory = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), @"..\LocalLow\THQNOnline\Kingdoms of Amalur Re-Reckoning\autocloud\save");
-            if (Directory.Exists(directory))
+            try
             {
-                return directory;
+                // GOG
+                var directory = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), @"..\LocalLow\THQNOnline\Kingdoms of Amalur Re-Reckoning\autocloud\save");
+                if (Directory.Exists(directory))
+                {
+                    return directory;
+                }
+                // Steam
+                directory = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86), "Steam", "userdata");
+                if (Directory.Exists(directory) && Directory.GetDirectories(directory) is string[] { Length: 1 } userDirs
+                        && (Directory.Exists(directory = Path.Combine(userDirs[0], @"1041720\remote\autocloud\save")) || Directory.Exists(directory = Path.Combine(userDirs[0], @"102500\remote"))))
+                {
+                    return directory;
+                }
             }
-            // Steam
-            directory = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86), "Steam", "userdata");
-            return Directory.Exists(directory) && Directory.GetDirectories(directory) is string[] { Length: 1 } userDirs 
-                    && (Directory.Exists(directory = Path.Combine(userDirs[0], @"1041720\remote\autocloud\save")) || Directory.Exists(directory = Path.Combine(userDirs[0], @"102500\remote")))
-                ? directory
-                : null;
+            catch
+            {
+            }
+            return Environment.CurrentDirectory;
         }
     }
 }

--- a/KoAR.Core/Amalur.cs
+++ b/KoAR.Core/Amalur.cs
@@ -60,13 +60,13 @@ namespace KoAR.Core
             try
             {
                 // GOG
-                var directory = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), @"..\LocalLow\THQNOnline\Kingdoms of Amalur Re-Reckoning\autocloud\save");
+                var directory = Path.Combine(Path.GetFullPath(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData, Environment.SpecialFolderOption.DoNotVerify)), @"..\LocalLow\THQNOnline\Kingdoms of Amalur Re-Reckoning\autocloud\save");
                 if (Directory.Exists(directory))
                 {
                     return directory;
                 }
                 // Steam
-                directory = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86), "Steam", "userdata");
+                directory = Path.Combine(Path.GetFullPath(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86, Environment.SpecialFolderOption.DoNotVerify)), "Steam", "userdata");
                 if (Directory.Exists(directory) && Directory.GetDirectories(directory) is string[] { Length: 1 } userDirs
                         && (Directory.Exists(directory = Path.Combine(userDirs[0], @"1041720\remote\autocloud\save")) || Directory.Exists(directory = Path.Combine(userDirs[0], @"102500\remote"))))
                 {

--- a/KoAR.Core/Amalur.cs
+++ b/KoAR.Core/Amalur.cs
@@ -60,7 +60,7 @@ namespace KoAR.Core
             try
             {
                 // GOG
-                var directory = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData, Environment.SpecialFolderOption.DoNotVerify), @"..\LocalLow\THQNOnline\Kingdoms of Amalur Re-Reckoning\autocloud\save");
+                var directory = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile, Environment.SpecialFolderOption.DoNotVerify), @"appdata\LocalLow\THQNOnline\Kingdoms of Amalur Re-Reckoning\autocloud\save");
                 if (Directory.Exists(directory))
                 {
                     return directory;

--- a/KoAR.Core/Amalur.cs
+++ b/KoAR.Core/Amalur.cs
@@ -60,13 +60,13 @@ namespace KoAR.Core
             try
             {
                 // GOG
-                var directory = Path.Combine(Path.GetFullPath(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData, Environment.SpecialFolderOption.DoNotVerify)), @"..\LocalLow\THQNOnline\Kingdoms of Amalur Re-Reckoning\autocloud\save");
+                var directory = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData, Environment.SpecialFolderOption.DoNotVerify), @"..\LocalLow\THQNOnline\Kingdoms of Amalur Re-Reckoning\autocloud\save");
                 if (Directory.Exists(directory))
                 {
                     return directory;
                 }
                 // Steam
-                directory = Path.Combine(Path.GetFullPath(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86, Environment.SpecialFolderOption.DoNotVerify)), "Steam", "userdata");
+                directory = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86, Environment.SpecialFolderOption.DoNotVerify), "Steam", "userdata");
                 if (Directory.Exists(directory) && Directory.GetDirectories(directory) is string[] { Length: 1 } userDirs
                         && (Directory.Exists(directory = Path.Combine(userDirs[0], @"1041720\remote\autocloud\save")) || Directory.Exists(directory = Path.Combine(userDirs[0], @"102500\remote"))))
                 {

--- a/KoAR.SaveEditor/Views/Main/MainWindowViewModel.cs
+++ b/KoAR.SaveEditor/Views/Main/MainWindowViewModel.cs
@@ -98,9 +98,9 @@ namespace KoAR.SaveEditor.Views.Main
                 DefaultExt = ".sav",
                 Filter = "Save Files (*.sav)|*.sav",
                 CheckFileExists = true,
-                InitialDirectory = string.IsNullOrEmpty(Settings.Default.LastDirectory)
+                InitialDirectory = Path.GetFullPath(string.IsNullOrEmpty(Settings.Default.LastDirectory)
                     ? Amalur.FindSaveGameDirectory()
-                    : Settings.Default.LastDirectory
+                    : Settings.Default.LastDirectory)
             };
             bool? result = default;
             try

--- a/KoAR.SaveEditor/Views/Main/MainWindowViewModel.cs
+++ b/KoAR.SaveEditor/Views/Main/MainWindowViewModel.cs
@@ -107,7 +107,7 @@ namespace KoAR.SaveEditor.Views.Main
             {
                 result = dialog.ShowDialog(Application.Current.MainWindow);
             }
-            catch (Exception e) when (e is IOException || e is UnauthorizedAccessException || e is ArgumentException)
+            catch
             {
                 dialog.InitialDirectory = Path.GetFullPath(Environment.GetFolderPath(Environment.SpecialFolder.Personal));
                 result = dialog.ShowDialog(Application.Current.MainWindow);

--- a/KoAR.SaveEditor/Views/Main/MainWindowViewModel.cs
+++ b/KoAR.SaveEditor/Views/Main/MainWindowViewModel.cs
@@ -102,7 +102,7 @@ namespace KoAR.SaveEditor.Views.Main
                     ? Amalur.FindSaveGameDirectory()
                     : Settings.Default.LastDirectory)
             };
-            bool? result = default;
+            bool? result;
             try
             {
                 result = dialog.ShowDialog(Application.Current.MainWindow);
@@ -110,6 +110,7 @@ namespace KoAR.SaveEditor.Views.Main
             catch (Exception e) when (e is IOException || e is UnauthorizedAccessException || e is ArgumentException)
             {
                 dialog.InitialDirectory = Path.GetFullPath(Environment.GetFolderPath(Environment.SpecialFolder.Personal));
+                result = dialog.ShowDialog(Application.Current.MainWindow);
             }
             if (result != true || this.CancelDueToUnsavedChanges(
                 $"Ignore.\nLoad \"{dialog.FileName}\" without saving the current file.",


### PR DESCRIPTION
Following guidance from this thread: https://stackoverflow.com/questions/14204598/exception-when-calling-showdialog-on-a-microsoft-win32-openfiledialog/18966278
Closes #67