### PR TITLE
Version in csproj.

### DIFF
--- a/KoAR.Core/KoAR.Core.csproj
+++ b/KoAR.Core/KoAR.Core.csproj
@@ -19,6 +19,12 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(BUILD_BUILDID)' == '' ">
+	<Version>3.0.0</Version>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(BUILD_BUILDID)' != '' ">
+	<Version>3.0.$(BUILD_BUILDID)</Version>
+  </PropertyGroup>
   <ItemGroup>
     <None Remove="Data.zip" />
   </ItemGroup>

--- a/KoAR.SaveEditor/KoAR.SaveEditor.csproj
+++ b/KoAR.SaveEditor/KoAR.SaveEditor.csproj
@@ -23,7 +23,6 @@
     <RepositoryUrl>https://github.com/mburbea/koar-item-editor</RepositoryUrl>
     <NeutralLanguage>en-US</NeutralLanguage>
     <UserSecretsId>08a013c8-a2ef-43c0-9e42-9500e36a74d4</UserSecretsId>
-    <Version>3.0.0</Version>
     <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -33,6 +32,12 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <PlatformTarget>AnyCPU</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(BUILD_BUILDID)' == '' ">
+	<Version>3.0.0</Version>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(BUILD_BUILDID)' != '' ">
+	<Version>3.0.$(BUILD_BUILDID)</Version>
   </PropertyGroup>
   <ItemGroup>
     <None Remove="app.ico" />

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 ## Kingdoms of Amalur: Reckoning (and Re-Reckoning) Save Editor
-This is heavily updated editor, rewritten in WPF and modern C# 8 paradigms. A product of Covid-19 quarantine and my frustrations with this game. 
+This is heavily updated editor, rewritten in WPF and modern C# 8 paradigms. A product of Covid-19 quarantine and my frustrations with this game.
+
+[![Build Status](https://dev.azure.com/amirburbea/koar/_apis/build/status/Build%20Save%20Editor?branchName=master)](https://dev.azure.com/amirburbea/koar/_build/latest?definitionId=1&branchName=master)
 
 ### Versioning Strategy
 * Version 3.x will be for the Remaster.


### PR DESCRIPTION
AzureDevOps variables can be accessed in the csproj (but won't exist locally). So now we don't need a step for mainfest attribute updates.

NetFX builds do not allow conditional per property, so we have to use the older PropertyGroup conditionals.
In .net 5 we can use this instead::
```xml
<Version Condition=" '$(BUILD_BUILDID)' == '' ">3.0.0</Version>
<Version Condition=" '$(BUILD_BUILDID)' != '' ">3.0.$(BUILD_BUILDID)</Version>
```

We can additionally make it simpler and just not care about our local build number and remove the normal version, which will make our app report 0.0.0.0 locally. 